### PR TITLE
XML files now validate

### DIFF
--- a/schema/commonTypes.xsd
+++ b/schema/commonTypes.xsd
@@ -28,14 +28,18 @@
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
-  <xs:complexType name="typed_identifier_type">
-    <xs:simpleContent>
-      <xs:restriction base="typed_string_type">
-        <xs:enumeration value="ORCID"/>
-        <xs:enumeration value="ResearcherID"/>
-        <xs:enumeration value="OceanExpert"/>
-      </xs:restriction>
-    </xs:simpleContent>
-  </xs:complexType>
-  
+  <xs:simpleType name="typed_person_identifier_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ORCID"/>
+      <xs:enumeration value="ResearcherID"/>
+      <xs:enumeration value="OceanExpert"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="typed_platform_identifier_type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ICES"/>
+      <xs:enumeration value="IMO"/>
+      <xs:enumeration value="WMO"/>
+    </xs:restriction>
+  </xs:simpleType>
 </xs:schema>

--- a/schema/oads_metadata.xsd
+++ b/schema/oads_metadata.xsd
@@ -39,7 +39,7 @@
       <xs:element name="title" type="xs:string"/>
       <xs:element name="abstract" type="xs:string"/>
       <xs:element name="useLimitation" type="xs:string" minOccurs="0"/>
-      <xs:element name="purpose" type="xs:string"/>
+      <xs:element name="purpose" type="xs:string" minOccurs="0"/>
       <xs:element name="methods" type="xs:string" minOccurs="0"/>
       <xs:element name="temporalExtents" type="temporal_extents_type"/>
       <xs:element name="spatialExtents" type="geospatial_extents_type"/>
@@ -88,11 +88,13 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="cruiseIds" minOccurs="0">
+      <xs:element name="cruiseIds" minOccurs="0" maxOccurs="unbounded">
         <xs:complexType>
-          <xs:sequence>
-            <xs:element name="cruiseId" type="typed_identifier_type" maxOccurs="unbounded"/>
-          </xs:sequence>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="type" type="typed_platform_identifier_type" use="required" />
+            </xs:extension>
+          </xs:simpleContent>
         </xs:complexType>
       </xs:element>
       <xs:element name="sections" minOccurs="0">
@@ -189,7 +191,7 @@
       <xs:element name="agency" type="xs:string"/>
       <!-- and/or org-ref -->
       <xs:element name="title" type="xs:string"/>
-      <xs:element name="identifier" type="typed_identifier_type"/>
+      <xs:element name="identifier" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
     </xs:sequence>
   </xs:complexType>
   <!--
@@ -204,7 +206,15 @@
   <xs:complexType name="platform_type">
     <xs:sequence>
       <xs:element name="name" type="xs:string"/>
-      <xs:element name="identifier" type="typed_identifier_type"/>
+      <xs:element name="identifier" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="type" type="typed_platform_identifier_type" use="required" />
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
       <xs:element name="type" type="xs:string" /> <!-- type_platform_type"/> --> <!-- ??? controlled vocab -->
       <xs:element name="owner" type="xs:string"/> <!-- and/or org-ref -->
       <xs:element name="country" type="xs:string"/> <!-- controlled vocab -->

--- a/schema/person.xsd
+++ b/schema/person.xsd
@@ -16,9 +16,25 @@
     <xs:sequence>
       <xs:element name="name" type="person_name_type" />
       <xs:element name="organization" type="xs:string" />
-      <xs:element name="organizationID" type="typed_identifier_type" />
+      <xs:element name="organizationID" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="type" type="typed_person_identifier_type" use="required" />
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
       <xs:element name="contactInfo" type="person_contact_info_type" />
-      <xs:element name="identifier" type="typed_identifier_type" minOccurs="0" maxOccurs="unbounded" nillable="true" />
+      <xs:element name="identifier" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="type" type="typed_person_identifier_type" use="required" />
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
       <xs:element name="link" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>

--- a/schema/variables.xsd
+++ b/schema/variables.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://ncei.noaa.gov/oads/v_a0_2_2s"
 	xmlns="http://ncei.noaa.gov/oads/v_a0_2_2s" elementFormDefault="qualified"
   xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1"
->
+  >
 
   <xs:include schemaLocation="commonTypes.xsd" />
   <!-- xs:include schemaLocation="instruments.xsd" / -->
@@ -25,9 +25,9 @@
 How the variable is observed, e.g., surface underway, profile, time series, model output, etc. 
 For experimental data, this could be: laboratory experiment, pelagic mesocosm, benthic mesocosm, 
                                       benthic FOCE type studies, natural pertubration site studies, etc
- -->
+                                    -->
   <!-- It would be good if this were a controlled vocabulary like below, 
-       but that may be difficult. -->
+  but that may be difficult. -->
   <xs:simpleType name="observation_type">
     <xs:restriction base="xs:string">
       <xs:enumeration value="Point" />
@@ -41,61 +41,61 @@ For experimental data, this could be: laboratory experiment, pelagic mesocosm, b
 
   <xs:group name="base_variable_elements">
     <xs:sequence>
-    <xs:element name="fullName" type="xs:string" />
-    <xs:element name="datasetVarName" type="xs:string" >
-      <xs:annotation>
-        <xs:documentation>
-          This is the name of the variable it the data file.
-          It may or may not be an abbreviation, and may, in some cases, contain additional information, such as units.
-        </xs:documentation>
-      </xs:annotation>
-    </xs:element>
-    <xs:element name="variableType" type="xs:string" >
-      <xs:annotation>
-        <xs:documentation>
-          This is the so-called "Details of the Observation" field: whether it is in-situ, manipulation condition, or response variable.  
-          It should really be of type variable_type.
-        </xs:documentation>
-      </xs:annotation>
-    </xs:element> 
-    <xs:element name="measuredOrCalculated" type="xs:string" >
-      <xs:annotation>
-        <xs:documentation>
-          Whether this variable was measured or calculated.  Allowed values are "Measured" or "Calculated".
-          However, actual values in older XML may be different.
-        </xs:documentation>
-      </xs:annotation>
-    </xs:element> 
-    <xs:element name="observationType" type="xs:string" >
-      <xs:annotation>
-        <xs:documentation>
-          How the variable is observed, e.g., surface underway, profile, time series, model output, etc. 
-          For experimental data, this could be: laboratory experiment, pelagic mesocosm, benthic mesocosm, 
-          benthic FOCE type studies, natural pertubration site studies, etc
-        </xs:documentation>
-      </xs:annotation>
-    </xs:element> 
-    <xs:element name="units" type="xs:string" minOccurs="0" />
-    <xs:element name="missingValue" type="xs:string" minOccurs="0"/>
-    <xs:element name="uncertainty" type="xs:string" minOccurs="0"/>
-    <xs:element name="qcFlag" type="qc_flag_info_type" minOccurs="0" />
-    <xs:element name="researcher" type="person_reference_type" /> <!-- ??? multiple ? -->
-    <xs:element name="methodReference" type="xs:string" minOccurs="0" /> <!-- ??? multiple ? -->
-    <xs:element name="variationsFromMethod" type="xs:string" minOccurs="0" />
-    <xs:element name="calculationMethod" type="calculation_method_type" minOccurs="0"/>
-    <xs:element name="manipulationMethod" type="xs:string" minOccurs="0" />   <!-- XXX only in manipulation type variables ? -->
-    <xs:element name="samplingInstrument" type="xs:string" minOccurs="0" /> 
-    <xs:element name="detailedSamplingInfo" type="xs:string" minOccurs="0" />   <!-- XXX methodDescription -->
-    <xs:element name="analyzingInstrument" type="xs:string" minOccurs="0" />
-    <xs:element name="detailedAnalyzingInfo" type="xs:string" minOccurs="0" />   <!-- XXX methodDescription -->
-    <xs:element name="fieldReplicateHandling" type="xs:string" minOccurs="0" /> 
-    <xs:element name="standardization" type="standardization_type" minOccurs="0" /> 
+      <xs:element name="fullName" type="xs:string" />
+      <xs:element name="datasetVarName" type="xs:string" >
+        <xs:annotation>
+          <xs:documentation>
+            This is the name of the variable it the data file.
+            It may or may not be an abbreviation, and may, in some cases, contain additional information, such as units.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="variableType" type="xs:string" >
+        <xs:annotation>
+          <xs:documentation>
+            This is the so-called "Details of the Observation" field: whether it is in-situ, manipulation condition, or response variable.  
+            It should really be of type variable_type.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element> 
+      <xs:element name="measuredOrCalculated" type="xs:string" >
+        <xs:annotation>
+          <xs:documentation>
+            Whether this variable was measured or calculated.  Allowed values are "Measured" or "Calculated".
+            However, actual values in older XML may be different.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element> 
+      <xs:element name="observationType" type="xs:string" >
+        <xs:annotation>
+          <xs:documentation>
+            How the variable is observed, e.g., surface underway, profile, time series, model output, etc. 
+            For experimental data, this could be: laboratory experiment, pelagic mesocosm, benthic mesocosm, 
+            benthic FOCE type studies, natural pertubration site studies, etc
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element> 
+      <xs:element name="units" type="xs:string" minOccurs="0" />
+      <xs:element name="missingValue" type="xs:string" minOccurs="0"/>
+      <xs:element name="uncertainty" type="xs:string" minOccurs="0"/>
+      <xs:element name="qcFlag" type="qc_flag_info_type" minOccurs="0" />
+      <xs:element name="researcher" type="person_reference_type" minOccurs="0"/> <!-- ??? multiple ? -->
+      <xs:element name="methodReference" type="xs:string" minOccurs="0" /> <!-- ??? multiple ? -->
+      <xs:element name="variationsFromMethod" type="xs:string" minOccurs="0" />
+      <xs:element name="calculationMethod" type="calculation_method_type" minOccurs="0"/>
+      <xs:element name="manipulationMethod" type="xs:string" minOccurs="0" />   <!-- XXX only in manipulation type variables ? -->
+      <xs:element name="samplingInstrument" type="xs:string" minOccurs="0" /> 
+      <xs:element name="detailedSamplingInfo" type="xs:string" minOccurs="0" />   <!-- XXX methodDescription -->
+      <xs:element name="analyzingInstrument" type="xs:string" minOccurs="0" />
+      <xs:element name="detailedAnalyzingInfo" type="xs:string" minOccurs="0" />   <!-- XXX methodDescription -->
+      <!-- <xs:element name="fieldReplicateHandling" type="xs:string" minOccurs="0" /> Not required for SOCAT -->
+      <xs:element name="standardization" type="standardization_type" minOccurs="0" /> 
     </xs:sequence>
   </xs:group>
   <xs:complexType name="base_variable_type">
-        <xs:sequence>
-          <xs:group ref="base_variable_elements"/>
-        </xs:sequence>
+    <xs:sequence>
+      <xs:group ref="base_variable_elements"/>
+    </xs:sequence>
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
         <xs:documentation>
@@ -112,10 +112,10 @@ For experimental data, this could be: laboratory experiment, pelagic mesocosm, b
         <xs:sequence>
           <xs:element name="poison" type="poison_type" minOccurs="0" /> 
         </xs:sequence>
-     </xs:extension>
+      </xs:extension>
     </xs:complexContent>
   </xs:complexType>
- 
+
   <xs:complexType name="ta_variable_type"> <!-- TA -->
     <xs:complexContent>
       <xs:extension base="dic_variable_type">
@@ -147,8 +147,8 @@ For experimental data, this could be: laboratory experiment, pelagic mesocosm, b
     <xs:complexContent>
       <xs:extension base="base_variable_type">
         <xs:sequence>
-          <xs:element name="gasDetector" type="gas_detector_type"/>
-          <xs:element name="waterVaporCorrection" type="xs:string" />
+          <xs:element name="gasDetector" type="gas_detector_type" minOccurs="0"/>
+          <xs:element name="waterVaporCorrection" type="xs:string" minOccurs="0"/>
           <xs:element name="temperatureCorrectionMethod" type="xs:string" />
           <xs:element name="calculationMethodFor_pCO2" type="xs:string" minOccurs="0"/>
           <xs:element name="calculationMethodFor_fCO2" type="xs:string" minOccurs="0"/>
@@ -167,121 +167,121 @@ For experimental data, this could be: laboratory experiment, pelagic mesocosm, b
           <xs:element name="equilibrator" minOccurs="0" type="equilibrator_type" />
           <!-- In co2_socat
           <xs:element name="totalPressureMeasurement" type="equilibrator_measurement_type" minOccurs="0" />
-          -->
-          <xs:element name="co2GasDryingMethod" type="xs:string" minOccurs="0" />
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
- 
-  <xs:complexType name="co2_socat">
-    <xs:complexContent>
-      <xs:extension base="co2_autonomous">
-        <xs:sequence>
-          <xs:element name="totalMeasurementPressure" type="equilibrator_measurement_type" minOccurs="0" />
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  
-  <xs:complexType name="co2_discrete">
-    <xs:complexContent>
-      <xs:extension base="co2_base">
-        <xs:sequence>
-          <xs:element name="storageMethod" type="xs:string" />
-          <xs:element name="seawaterVolume" type="xs:string" />
-          <xs:element name="headspaceVolume" type="xs:string" />
-          <xs:element name="measurementTemperature" type="xs:string" />
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  
-  <xs:complexType name="biological_variable">
-    <xs:complexContent>
-      <xs:extension base="base_variable_type">  <!-- Unsure about this. Perhaps "observered_variable" ? -->
-        <xs:sequence>
-          <xs:element name="duration" minOccurs="0" type="xs:string" />
-          <xs:element name="biologicalSubject" type="xs:string" />
-          <xs:element name="speciesID" type="xs:string" />
-          <xs:element name="lifeStage" type="xs:string" />
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
+        -->
+        <xs:element name="co2GasDryingMethod" type="xs:string" minOccurs="0" />
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
 
-  <xs:complexType name="qc_flag_info_type">
-    <xs:sequence>
+<xs:complexType name="co2_socat">
+  <xs:complexContent>
+    <xs:extension base="co2_autonomous">
+      <xs:sequence>
+        <xs:element name="totalMeasurementPressure" type="equilibrator_measurement_type" minOccurs="0" />
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:complexType name="co2_discrete">
+  <xs:complexContent>
+    <xs:extension base="co2_base">
+      <xs:sequence>
+        <xs:element name="storageMethod" type="xs:string" />
+        <xs:element name="seawaterVolume" type="xs:string" />
+        <xs:element name="headspaceVolume" type="xs:string" />
+        <xs:element name="measurementTemperature" type="xs:string" />
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:complexType name="biological_variable">
+  <xs:complexContent>
+    <xs:extension base="base_variable_type">  <!-- Unsure about this. Perhaps "observered_variable" ? -->
+      <xs:sequence>
+        <xs:element name="duration" minOccurs="0" type="xs:string" />
+        <xs:element name="biologicalSubject" type="xs:string" />
+        <xs:element name="speciesID" type="xs:string" />
+        <xs:element name="lifeStage" type="xs:string" />
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+
+<xs:complexType name="qc_flag_info_type">
+  <xs:sequence>
     <!-- Do we need to have both? -->
-      <xs:element name="scheme" type="xs:string" minOccurs="0"/>
-      <xs:element name="description" type="xs:string" minOccurs="0"/>
-      <xs:element name="qcFlagVarName" type="xs:string" minOccurs="0"/> <!-- XXX ??? if missing, assume datasetVarName + "_qc" -->
-    </xs:sequence>
-  </xs:complexType>
- 
-  <xs:complexType name="calibration_type" >
-    <xs:sequence>
-      <xs:element name="method" type="xs:string" />
-      <xs:element name="frequency" type="xs:string" />
-    </xs:sequence>
-  </xs:complexType>
-  
-  <xs:complexType name="equilibrator_type" >
-    <xs:sequence>
-      <xs:element name="type" type="xs:string" minOccurs="0" />
-      <xs:element name="volume" type="xs:string" minOccurs="0" />
-      <xs:element name="vented" type="xs:string" minOccurs="0" />
-      <xs:element name="waterFlowRate" type="xs:string" minOccurs="0" />
-      <xs:element name="gasFlowRate" type="xs:string" minOccurs="0" />
-      <xs:element name="temperatureMeasurement" type="equilibrator_measurement_type"  minOccurs="0" />
-      <xs:element name="pressureMeasurement" type="equilibrator_measurement_type"  minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-      
-  <xs:complexType name="equilibrator_measurement_type">
-    <xs:sequence>
-      <xs:element name="method" type="xs:string" />
-      <xs:element name="sensor" type="instrument_type" minOccurs="0"/>
-      <xs:element name="sensorLocation" type="xs:string" minOccurs="0"/>
-      <xs:element name="uncertainty" type="xs:string" />
-      <xs:element name="comments" type="xs:string" />
-    </xs:sequence>
-  </xs:complexType>
-  
-  <xs:complexType name="instrument_type">
-    <xs:sequence>
-      <xs:element name="manufacturer" type="xs:string" />
-      <xs:element name="model" type="xs:string" />
-      <xs:element name="accuracy" type="xs:string" />
-      <xs:element name="precision" type="xs:string" />
-      <xs:element name="calibration" type="xs:string" /> <!--  type="calibration_type" />  -->
-    </xs:sequence>
-  </xs:complexType>
-  
-  <xs:complexType name="gas_detector_type">
-    <xs:sequence>
-      <xs:element name="manufacturer" type="xs:string" minOccurs="0" />
-      <xs:element name="model" type="xs:string" minOccurs="0" />
-      <xs:element name="resolution" type="xs:string" minOccurs="0" />
-      <xs:element name="uncertainty" type="xs:string" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-        
-  <xs:complexType name="standardization_type">
-    <xs:sequence>
-      <xs:element name="description" type="xs:string" />
-      <xs:element name="frequency" type="xs:string" />
-      <xs:element name="temperature" type="xs:string" minOccurs="0" /> 
-      <xs:choice>
-        <xs:sequence>
-          <xs:element name="standardGas" type="standard_gas_type" minOccurs="0" maxOccurs="unbounded" /> <!-- CO2 variables -->
-          <xs:element name="crm" type="crm_type" minOccurs="0" /> <!-- DIC / TA -->
-        </xs:sequence>
-      </xs:choice>
-      <xs:element name="phOfStandards"  type="xs:string" minOccurs="0"/> <!-- ph only -->          
-    </xs:sequence>
-  </xs:complexType>
-  
+    <xs:element name="scheme" type="xs:string" minOccurs="0"/>
+    <xs:element name="description" type="xs:string" minOccurs="0"/>
+    <xs:element name="qcFlagVarName" type="xs:string" minOccurs="0"/> <!-- XXX ??? if missing, assume datasetVarName + "_qc" -->
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="calibration_type" >
+  <xs:sequence>
+    <xs:element name="method" type="xs:string" />
+    <xs:element name="frequency" type="xs:string" />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="equilibrator_type" >
+  <xs:sequence>
+    <xs:element name="type" type="xs:string" minOccurs="0" />
+    <xs:element name="volume" type="xs:string" minOccurs="0" />
+    <xs:element name="vented" type="xs:string" minOccurs="0" />
+    <xs:element name="waterFlowRate" type="xs:string" minOccurs="0" />
+    <xs:element name="gasFlowRate" type="xs:string" minOccurs="0" />
+    <xs:element name="temperatureMeasurement" type="equilibrator_measurement_type"  minOccurs="0" />
+    <xs:element name="pressureMeasurement" type="equilibrator_measurement_type"  minOccurs="0" />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="equilibrator_measurement_type">
+  <xs:sequence>
+    <xs:element name="method" type="xs:string" />
+    <xs:element name="sensor" type="instrument_type" minOccurs="0"/>
+    <xs:element name="sensorLocation" type="xs:string" minOccurs="0"/>
+    <xs:element name="uncertainty" type="xs:string" />
+    <xs:element name="comments" type="xs:string" />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="instrument_type">
+  <xs:sequence>
+    <xs:element name="manufacturer" type="xs:string" />
+    <xs:element name="model" type="xs:string" />
+    <xs:element name="accuracy" type="xs:string" />
+    <xs:element name="precision" type="xs:string" />
+    <xs:element name="calibration" type="xs:string" /> <!--  type="calibration_type" />  -->
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="gas_detector_type">
+  <xs:sequence>
+    <xs:element name="manufacturer" type="xs:string" minOccurs="0" />
+    <xs:element name="model" type="xs:string" minOccurs="0" />
+    <xs:element name="resolution" type="xs:string" minOccurs="0" />
+    <xs:element name="uncertainty" type="xs:string" minOccurs="0" />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="standardization_type">
+  <xs:sequence>
+    <xs:element name="description" type="xs:string" />
+    <xs:element name="frequency" type="xs:string" />
+    <xs:element name="temperature" type="xs:string" minOccurs="0" /> 
+    <xs:choice>
+      <xs:sequence>
+        <xs:element name="standardGas" type="standard_gas_type" minOccurs="0" maxOccurs="unbounded" /> <!-- CO2 variables -->
+        <xs:element name="crm" type="crm_type" minOccurs="0" /> <!-- DIC / TA -->
+      </xs:sequence>
+    </xs:choice>
+    <xs:element name="phOfStandards"  type="xs:string" minOccurs="0"/> <!-- ph only -->          
+  </xs:sequence>
+</xs:complexType>
+
 <!-- added too much unnecessary complexity
   <xs:complexType name="ph_standardization_type">
     <xs:complexContent>
@@ -294,43 +294,43 @@ For experimental data, this could be: laboratory experiment, pelagic mesocosm, b
   </xs:complexType>
 --> 
 
-  <xs:complexType name="crm_type">
-    <xs:sequence>
-      <xs:element name="manufacturer" type="xs:string" />
-      <xs:element name="batch"  type="xs:string" minOccurs="0" />
-      <xs:element name="bottle"   type="xs:string" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-  
-  <xs:complexType name="standard_gas_type">
-    <xs:sequence>
-      <xs:element name="manufacturer" type="xs:string" minOccurs="0" />
-      <xs:element name="concentration" type="xs:string" minOccurs="0" />
-      <xs:element name="uncertainty" type="xs:string" minOccurs="0" />
-      <xs:element name="traceabilityToWmoStandards" type="xs:string" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="poison_type">
-    <xs:sequence>
-      <xs:element name="name" type="xs:string" />
-    <!--  <xs:element name="description" type="xs:string" minOccurs="0" />  -->
-      <xs:element name="volume" type="xs:string" minOccurs="0" /> <!-- value_with_unit_type -->
-      <xs:element name="correction" type="xs:string" minOccurs="0" />
-    </xs:sequence>
-  </xs:complexType>
+<xs:complexType name="crm_type">
+  <xs:sequence>
+    <xs:element name="manufacturer" type="xs:string" />
+    <xs:element name="batch"  type="xs:string" minOccurs="0" />
+    <xs:element name="bottle"   type="xs:string" minOccurs="0" />
+  </xs:sequence>
+</xs:complexType>
 
-  <xs:complexType name="calculation_method_type">
-    <xs:sequence>
-      <xs:element name="description" type="xs:string" />
-      <xs:element name="parameter" type="calculation_parameter_type" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>    
-  
-  <xs:complexType name="calculation_parameter_type">
-    <xs:simpleContent>
-      <xs:extension base="xs:anySimpleType">
-        <xs:attribute name="name" type="xs:string" />
-      </xs:extension>
-    </xs:simpleContent>
-  </xs:complexType>
+<xs:complexType name="standard_gas_type">
+  <xs:sequence>
+    <xs:element name="manufacturer" type="xs:string" minOccurs="0" />
+    <xs:element name="concentration" type="xs:string" minOccurs="0" />
+    <xs:element name="uncertainty" type="xs:string" minOccurs="0" />
+    <xs:element name="traceabilityToWmoStandards" type="xs:string" minOccurs="0" />
+  </xs:sequence>
+</xs:complexType>
+<xs:complexType name="poison_type">
+  <xs:sequence>
+    <xs:element name="name" type="xs:string" />
+    <!--  <xs:element name="description" type="xs:string" minOccurs="0" />  -->
+    <xs:element name="volume" type="xs:string" minOccurs="0" /> <!-- value_with_unit_type -->
+    <xs:element name="correction" type="xs:string" minOccurs="0" />
+  </xs:sequence>
+</xs:complexType>
+
+<xs:complexType name="calculation_method_type">
+  <xs:sequence>
+    <xs:element name="description" type="xs:string" />
+    <xs:element name="parameter" type="calculation_parameter_type" minOccurs="0" maxOccurs="unbounded" />
+  </xs:sequence>
+</xs:complexType>    
+
+<xs:complexType name="calculation_parameter_type">
+  <xs:simpleContent>
+    <xs:extension base="xs:anySimpleType">
+      <xs:attribute name="name" type="xs:string" />
+    </xs:extension>
+  </xs:simpleContent>
+</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Adjustments to the XSD files so that XML files built in the metadata editor can be validated. Note that validated XML files loaded into the online editor will lose information.

One thing I can't figure out: variables of the type `xsi:type="co2_socat"` require all child elements, even though they're set to `minOccurs="0"`. There's something I don't understand here. The intention is that one of the `co2_socat` variables contains all the child elements, but not the others. Therefore they should be optional. But as I say, the validator complains about missing child elements.

Used `xmllint` as validator.

Attached file is a ZIPped XML file that validates against these XSD files.

[119920220401.xml.zip](https://github.com/NOAA-PMEL/OAPMetadata/files/13219083/119920220401.xml.zip)
